### PR TITLE
feat: added ability to open VS Code window that attaches to an existi…

### DIFF
--- a/src/common/remote-ssh-connect.ts
+++ b/src/common/remote-ssh-connect.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+
+// export async function connectToRemoteSSH() {
+//     // The command ID and the arguments you want to pass
+//     const command = 'opensshremotes.openEmptyWindow';
+//     const host = 'root@localhost:8898';
+
+//     try {
+//         await vscode.commands.executeCommand(command, host);
+//         vscode.window.showInformationMessage('Successfully connected to Remote SSH!');
+//     } catch (error) {
+//         vscode.window.showErrorMessage(`Failed to connect to Remote SSH: ${error}`);
+//     }
+// }
+
+export async function connectToRemoteSSH() {
+    const sshName = "root@localhost:8022";
+    try {
+        await vscode.commands.executeCommand("vscode.newWindow", {
+            remoteAuthority: `ssh-remote+${sshName}`
+        });
+        copyPasswordToClipboard();
+        vscode.window.showInformationMessage(`Successfully connected to ${sshName}`);
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to connect to ${sshName}: ${error.message}`);
+    }
+}
+
+async function copyPasswordToClipboard() {
+    const password = "pass";
+
+    try {
+        await vscode.env.clipboard.writeText(password);
+        vscode.window.showInformationMessage('Password has been copied to the clipboard!');
+    } catch (error) {
+        vscode.window.showErrorMessage('Failed to copy password to the clipboard.');
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import fs from 'fs';
 import { readClearMLAuthSettingsFromConfigFile } from './common/clearml/clearml-conf';
 import { ClearMLApiClient } from './common/clearml/api-client';
 import { startDetachedSubprocess } from './common/shell';
+import { connectToRemoteSSH } from './common/remote-ssh-connect';
 
 
 // This method is called when your extension is activated
@@ -43,12 +44,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	})
 
 	vscode.commands.registerCommand('clearmlSessions.attachToSession', async (session: ClearmlSession) => {
-		await initializePython(context.subscriptions);
-		const settings = await getWorkspaceSettings(consts.SETTINGS_NAMESPACE, vscode.workspace.workspaceFolders![0], true)
-		const interpreterFpath: string = settings.interpreter[0]
-		startDetachedSubprocess(
-			interpreterFpath, ["-m", "clearml_session", "--attach", session.taskId], 
-		)
+		// await initializePython(context.subscriptions);
+		// const settings = await getWorkspaceSettings(consts.SETTINGS_NAMESPACE, vscode.workspace.workspaceFolders![0], true)
+		// const interpreterFpath: string = settings.interpreter[0]
+		// startDetachedSubprocess(
+		// 	interpreterFpath, ["-m", "clearml_session", "--attach", session.taskId], 
+		// )
+		await connectToRemoteSSH();
 	})
 	vscode.commands.registerCommand('clearmlSessions.copyValueToClipboard', async (treeItem: vscode.TreeItem) => {
 		if (treeItem.description) {


### PR DESCRIPTION
Video describing the changes here: https://share.descript.com/view/dRoWrZI5NB3

Here's the command I ran to start the ClearML session shown in this video:

```bash
# set up clearml
pip install clearml clearml-session
clearml-init # you'll be prompted to paste ClearML creds that you must get from the ClearML UI

# remove previous state and start a ClearML session
rm ~/.clearml_session.json || true
clearml-session \
    --queue aws-ec2 \
    --docker python:3.9 \
    --public-ip true \
    --username root \
    --password "pass" \
    --init-script ~/Desktop/on-startup.sh \
    --docker-args '--network host -v /var/run/docker.sock:/var/run/docker.sock' \
    --packages boto3 \
    --yes \
    --verbose
```

Here's my `on-startup.sh` script:

It sets up the session just the way I like it, e.g. makes the terminal pretty with ZSH

![image](https://github.com/mlops-club/vscode-clearml-session-manager/assets/32227767/2640ad5c-fd76-4388-8dbe-5af24f01afd6)


```bash
set -x
df -h

apt-get update && apt-get install curl zip -y

# move the SSH keys -- because the EC2 key pair is the same as my laptop's SSH key,
# which ends up getting mounted into the remote session and causes issues when 
# try to SSH in as the root user
mv ~/.ssh ~/.ssh_org

# aws cli
curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
unzip awscliv2.zip
./aws/install
echo 'PATH=/usr/local/bin:$PATH' >> ~/.bashrc
echo 'alias aws-refresh="SSO_START_URL=https://d-92676a831b.awsapps.com/start# aws configure sso --profile"' >> ~/.bashrc

# aws sso
mkdir -p ~/.aws/
cat <<EOT > ~/.aws/config
[sso-session benlabs]
sso_start_url = https://d-92676a831b.awsapps.com/start#
sso_region = us-west-2
sso_registration_scopes = sso:account:access
EOT

# set up ZSH, syntax-highlighting, auto-suggestions, bira theme
sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
    -t bira \
    -p git \
    -p python \
    -p pip \
    -p pyenv \
    -p virtualenv \
    -p docker \
    -p docker-compose \
    -p zsh-syntax-highlighting \
    -p zsh-autosuggestions \
    -p web-search \
    -a 'alias aws-refresh="SSO_START_URL=https://d-92676a831b.awsapps.com/start# aws configure sso --profile"' \
    -a 'PATH=/usr/local/bin:"$PATH"'
git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting

# install docker
curl -fsSL get.docker.com | bash

echo "on-startup.sh ran"
```